### PR TITLE
Remove configuration option Strict from workspace deegree-workspace-ogcri

### DIFF
--- a/deegree-workspace-ogcri/services/wms111.xml
+++ b/deegree-workspace-ogcri/services/wms111.xml
@@ -6,5 +6,4 @@
   <wms:ServiceConfiguration>
     <wms:ThemeId>theme</wms:ThemeId>
   </wms:ServiceConfiguration>
-<wms:Strict>true</wms:Strict>
 </wms:deegreeWMS>


### PR DESCRIPTION
Configuration option `Strict` had to be removed because of following bug: https://github.com/deegree/deegree3/issues/1319